### PR TITLE
Add Dockerfile and documentation for containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Git specific
+.git
+.gitignore
+.gitattributes
+
+# Python specific
+*.pyc
+*.pyo
+__pycache__/
+*.egg-info/
+venv/
+env/
+.env
+*.venv
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Build artifacts
+build/
+dist/
+*.tar.gz
+*.zip
+
+# Data and Documentation (assuming not needed in the runtime image)
+data/
+docs/
+quantitative_evaluation/ # Contains scripts and data for evaluation, not runtime
+*.ipynb
+
+# OS specific
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Local files
+secrets.txt
+credentials.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Base image with CUDA and development tools
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+
+# Set DEBIAN_FRONTEND to noninteractive to avoid prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install essential Linux packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Miniconda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O ~/miniconda.sh &&     /bin/bash ~/miniconda.sh -b -p /opt/conda &&     rm ~/miniconda.sh &&     /opt/conda/bin/conda init &&     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh &&     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc &&     echo "conda activate base" >> ~/.bashrc
+
+# Set PATH to include conda
+ENV PATH /opt/conda/bin:$PATH
+
+# Create conda environment
+RUN conda create -n video_chatgpt python=3.10 -y
+SHELL ["conda", "run", "-n", "video_chatgpt", "/bin/bash", "-c"]
+
+# Set up the working directory
+WORKDIR /app
+
+# Copy requirements first to leverage Docker cache
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install -r requirements.txt
+
+# Install FlashAttention
+RUN apt-get update && apt-get install -y --no-install-recommends ninja-build && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/HazyResearch/flash-attention.git &&     cd flash-attention &&     git checkout v1.0.7 &&     python setup.py install &&     cd .. &&     rm -rf flash-attention
+
+# Copy the rest of the application code
+COPY . .
+
+# Set PYTHONPATH
+ENV PYTHONPATH="/app:$PYTHONPATH"
+
+# Expose default Gradio port (if the demo uses it)
+EXPOSE 7860
+
+# Default command (can be overridden)
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -233,3 +233,54 @@ Please raise any issues or questions [here](https://github.com/mbzuai-oryx/Video
 [<img src="docs/images/IVAL_logo.png" width="200" height="100">](https://www.ival-mbzuai.com)
 [<img src="docs/images/Oryx_logo.png" width="100" height="100">](https://github.com/mbzuai-oryx)
 [<img src="docs/images/MBZUAI_logo.png" width="360" height="85">](https://mbzuai.ac.ae)
+
+
+## Running with Docker :whale:
+
+This application can be built and run using Docker.
+
+### Prerequisites
+
+*   [Docker](https://docs.docker.com/get-docker/) installed on your system.
+*   If you require GPU access within the container (e.g., for CUDA applications), ensure you have the [NVIDIA Docker runtime](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed.
+
+### Building the Image
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/mbzuai-oryx/Video-ChatGPT.git
+    cd Video-ChatGPT
+    ```
+
+2.  **Build the Docker image:**
+    ```bash
+    docker build -t video-chatgpt:latest .
+    ```
+    This command builds the image using the `Dockerfile` in the current directory and tags it as `video-chatgpt:latest`.
+
+### Running the Container
+
+1.  **Run the container interactively (shell access):**
+    To start a container and get a bash shell inside it:
+    ```bash
+    docker run -it --rm video-chatgpt:latest
+    ```
+    If you need GPU access:
+    ```bash
+    docker run -it --rm --gpus all video-chatgpt:latest
+    ```
+
+2.  **Running the Gradio Demo:**
+    The Dockerfile exposes port 7860, which is commonly used by Gradio demos. To run the demo (assuming `video_chatgpt/demo/video_demo.py` is the entrypoint for it):
+    ```bash
+    docker run -it --rm --gpus all -p 7860:7860 video-chatgpt:latest python video_chatgpt/demo/video_demo.py
+    ```
+    You should then be able to access the demo in your web browser at `http://localhost:7860`.
+
+    *(Note: The exact command to run the demo might vary depending on the application's structure. You might need to adjust the python script path or command.)*
+
+### Additional Notes
+
+*   The `PYTHONPATH` is set to `/app` within the container.
+*   The working directory inside the container is `/app`.
+*   The application uses a conda environment named `video_chatgpt`.


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize the Video-ChatGPT application.

Key changes:
- Added a `Dockerfile` that sets up a Conda environment with Python 3.10, installs dependencies from `requirements.txt`, and compiles FlashAttention.
- Included an NVIDIA CUDA base image for GPU support.
- Added a `.dockerignore` file to exclude unnecessary files from the Docker build context, optimizing image size and build time.
- Updated `README.md` with a new "Running with Docker" section, providing instructions on how to build the Docker image and run the container, including options for GPU access and running the Gradio demo.

This allows for easier setup and deployment of the application in a consistent environment.